### PR TITLE
fix!: Change file ending of encrypted files to gpg

### DIFF
--- a/lib/backup/backup.sh
+++ b/lib/backup/backup.sh
@@ -76,6 +76,6 @@ backup_volume() {
 
   back
 
-  should_encrypt && backup_filename+=".enc"
+  should_encrypt && backup_filename+=".gpg"
   log "=> Backup finished: $backup_filename"
 }

--- a/lib/common/archiving.sh
+++ b/lib/common/archiving.sh
@@ -23,7 +23,7 @@ pack() {
     create_checksum "$1"
     verify_checksum "$1"
 
-    encrypt "$1" "$1.enc"
+    encrypt "$1" "$1.gpg"
 
   back
 
@@ -38,7 +38,7 @@ unpack() {
   log2 "+ Unpackaging process started"
 
   filename="$1"
-  filename_clean="${filename%*.enc}"
+  filename_clean="${filename%*.gpg}"
   target_path="${2:?}"
 
   decrypt "$filename" "$filename_clean"

--- a/lib/common/backups.sh
+++ b/lib/common/backups.sh
@@ -44,9 +44,9 @@ move_backup() {
 
   log3 "+ Moving process started"
 
-  backup_name="${1%*.enc}"
+  backup_name="${1%*.gpg}"
   copy_backup_files "$backup_name" "$2"
-  remove_file "$backup_name" "$backup_name.sfv" "$backup_name.enc" "$backup_name.enc.sfv"
+  remove_file "$backup_name" "$backup_name.sfv" "$backup_name.gpg" "$backup_name.gpg.sfv"
 
   log3 "- Moving process finished"
 }
@@ -56,13 +56,13 @@ copy_backup_files() {
 
   ! is_directory "$2" && error "Target path should be a directory"
 
-  backup_name="${1%*.enc}"
+  backup_name="${1%*.gpg}"
   copy_soft "$backup_name.sfv" "$2"
   copy_soft "$backup_name" "$2"
   verify_checksum "$2/$(basename "$backup_name")"
-  copy_soft "$backup_name.enc.sfv" "$2"
-  copy_soft "$backup_name.enc" "$2"
-  verify_checksum "$2/$(basename "$backup_name").enc"
+  copy_soft "$backup_name.gpg.sfv" "$2"
+  copy_soft "$backup_name.gpg" "$2"
+  verify_checksum "$2/$(basename "$backup_name").gpg"
 }
 
 # Helper functions

--- a/lib/common/encryption.sh
+++ b/lib/common/encryption.sh
@@ -62,7 +62,7 @@ verify_encryption() {
 
   log3 "+ Encryption verification process started"
 
-  backup_name="${1%*.enc}"
+  backup_name="${1%*.gpg}"
   tmp_name="$backup_name.tmp"
   copy_file "$backup_name.sfv" "$tmp_name.sfv"
 
@@ -93,7 +93,7 @@ decrypt_file() {
 
 # Checks if an archive is encrypted
 # Params: <archive filename/path>
-is_encrypted() { [[ "$1" =~ \.enc$ ]]; }
+is_encrypted() { [[ "$1" =~ \.gpg$ ]]; }
 
 # Checks if archives should be encrypted
 should_encrypt() { [ "$ENCRYPT_ARCHIVES" = "$TRUE" ]; }

--- a/lib/common/helpers.sh
+++ b/lib/common/helpers.sh
@@ -32,13 +32,13 @@ sudo_if_unwritable() {
 # Checks if a file is a backup
 # Params: <filename|path>
 is_backup() {
-  [[ "$(basename "$1")" =~ backup\-(.+?)\-[0-9]{14}\.(tgz|zip|rar|7z)(\.enc)?$ ]];
+  [[ "$(basename "$1")" =~ backup\-(.+?)\-[0-9]{14}\.(tgz|zip|rar|7z)(\.gpg)?$ ]];
 }
 
 # Checks if a file is a backup
 # Params: <filename|path>
 is_prerestore_backup() {
-  [[ "$(basename "$1")" =~ prerestore\+.+?\+[0-9]{14}\.(tgz|zip|rar|7z)(\.enc)?$ ]];
+  [[ "$(basename "$1")" =~ prerestore\+.+?\+[0-9]{14}\.(tgz|zip|rar|7z)(\.gpg)?$ ]];
 }
 
 # Checks if a given value is a volume name

--- a/tests/specs/integration_spec.sh
+++ b/tests/specs/integration_spec.sh
@@ -39,7 +39,7 @@ test__backup_remove_restore_encrypted_backup() {
   latest_backup="$(get_latest_backup test)"
   /bin/rm -f "$file_to_restore"
   assert_file_does_not_exist "$file_to_restore"
-  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".enc"
+  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".gpg"
 
   # Act
   run_restore "$latest_backup"
@@ -63,7 +63,7 @@ test__backup_remove_restore_verified_encrypted_backup() {
   latest_backup="$(get_latest_backup test)"
   /bin/rm -f "$file_to_restore"
   assert_file_does_not_exist "$file_to_restore"
-  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".enc"
+  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".gpg"
 
   # Act
   run_restore "$latest_backup"
@@ -86,7 +86,7 @@ test__restore_encrypted_with_bad_password() {
   latest_backup="$(get_latest_backup test)"
   /bin/rm -f "$file_to_restore"
   assert_file_does_not_exist "$file_to_restore"
-  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".enc"
+  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".gpg"
 
   # Act
   ENCRYPTION_PASSWORD=badpassword
@@ -111,7 +111,7 @@ test__backup_remove_restore_encrypted_twofish() {
   latest_backup="$(get_latest_backup test)"
   /bin/rm -f "$file_to_restore"
   assert_file_does_not_exist "$file_to_restore"
-  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".enc"
+  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".gpg"
 
   # Act
   run_restore "$latest_backup"
@@ -158,7 +158,7 @@ test__backup_remove_restore_prerestore_encrypted_backup() {
   run_restore "$latest_backup"
   /bin/rm -f "$file_to_restore"
   assert_file_does_not_exist "$file_to_restore"
-  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".enc"
+  assert_file_ends_with "$BACKUP_PATH/$latest_backup" ".gpg"
   prerestore_backup="$(get_latest_prerestore_backup "test")"
   assert_string_starts_with "$prerestore_backup" "prerestore\+backup\-test\-"
 


### PR DESCRIPTION
BREAKING CHANGE: Backup files ending in .enc will no longer be recognized as encrypted backups, and will need to be renamed.